### PR TITLE
Point at the raw file for APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Screen 1                          |Screen 2
 
 
 # Download
-You can download the apk here [SingleScreenApp](app/screenshots/app-debug.apk)
+You can download the apk here [SingleScreenApp](../../raw/master/app/screenshots/app-debug.apk)


### PR DESCRIPTION
Addresses the inability to download the APK as a file just by clicking the link. Does NOT require the use of the  GitHub`releases`, but forces a link to the `master` branch version of the file.